### PR TITLE
Support HumHub 1.19 asset layout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.4.2 (Unreleased)
+------------------
+- Enh #67: Remove directories left empty after update file deletions (`static` moved into `protected/humhub` with HumHub 1.19, humhub/humhub#8102)
+- Fix #67: Only check `static` folder permissions when the update package contains one
+
 2.4.1 (July 8, 2026)
 --------------------
 - Fix #60: Fix auto update modules

--- a/libs/UpdatePackage.php
+++ b/libs/UpdatePackage.php
@@ -154,9 +154,12 @@ class UpdatePackage
             $notWritable[] = $vendorPath;
         }
 
-        $webrootStaticPath = Yii::getAlias('@webroot/static');
-        if (!$this->isWritable($webrootStaticPath)) {
-            $notWritable[] = $webrootStaticPath;
+        // Only packages for HumHub prior 1.19 ship a complete `static` folder
+        if (is_dir($this->getNewFileDirectory() . DIRECTORY_SEPARATOR . 'static')) {
+            $webrootStaticPath = Yii::getAlias('@webroot/static');
+            if (!$this->isWritable($webrootStaticPath)) {
+                $notWritable[] = $webrootStaticPath;
+            }
         }
 
         // Test Backup Path
@@ -350,14 +353,33 @@ class UpdatePackage
     }
 
     /**
-     * Delete a file
+     * Delete a file and parent directories which were left empty, e.g. the `static`
+     * and `themes/HumHub` folders which moved into `protected/humhub` with HumHub 1.19
      *
-     * @todo Also delete parent directories - when empty
      * @param type $file
      */
     private function deleteFile($file)
     {
-        return @unlink($file);
+        if (!@unlink($file)) {
+            return false;
+        }
+
+        $webroot = realpath(Yii::getAlias('@webroot'));
+        if ($webroot === false) {
+            return true;
+        }
+
+        $directory = dirname($file);
+        while (
+            ($real = realpath($directory)) !== false
+            && $real !== $webroot
+            && str_starts_with($real, $webroot . DIRECTORY_SEPARATOR)
+            && @rmdir($real)
+        ) {
+            $directory = dirname($directory);
+        }
+
+        return true;
     }
 
     protected function getTempPath()

--- a/module.json
+++ b/module.json
@@ -9,5 +9,5 @@
     "humhub": {
         "minVersion": "1.18"
     },
-    "version": "2.4.1"
+    "version": "2.4.2"
 }


### PR DESCRIPTION
## Context

With [humhub/humhub#8102](https://github.com/humhub/humhub/pull/8102) (HumHub 1.19) the root `static` folder moved into `protected/humhub/resources` and built assets are generated by `grunt build-assets` instead of being committed. The package builder (humhub/web@61beb87) was adapted accordingly: update packages for 1.19+ no longer contain a complete `files/static` directory — the generated assets are shipped as regular changed files and the obsolete `static`/`themes/HumHub` files arrive as regular delete entries.

## Changes

- `UpdatePackage::deleteFile()` now removes parent directories which were left empty after a file deletion (bounded to inside the webroot, `rmdir` only ever removes empty directories). This cleans up the leftover `static` and `themes/HumHub` directory skeletons when updating from 1.18.x to 1.19. This also resolves the long-standing `@todo` on that method.
- `UpdatePackage::checkFilePermissions()` only requires `@webroot/static` to be writable when the update package actually ships a `files/static` directory (packages for HumHub < 1.19). Previously the check could falsely block updates on 1.19 installations without a `static` folder when the webroot itself is not writable.

Not breaking — works with packages for both layouts, `humhub.minVersion` stays at 1.18 so 1.18.x installations receive this updater version before updating to 1.19.